### PR TITLE
updates link to point to reference manual instead of 404 article

### DIFF
--- a/rackspace.yaml
+++ b/rackspace.yaml
@@ -16,10 +16,9 @@ abstract: |
   [Holland](https://github.com/holland-backup/holland#readme).
 instructions: |
   #### Getting Started
-  If you're new to MySQL, the [Getting Started with
-  MySQL](http://dev.mysql.com/tech-resources/articles/mysql_intro.html)
-  documentation will step you through the basics of configuration, user, and
-  permission management.
+  If you're new to MySQL, the [Manual](http://dev.mysql.com/doc/refman/5.5/en/index.html)
+  documentation will step you through the basics of configuration, connecting,
+ user, and  permission management.
 
   As a part of your server configuration, your server will be configured to run
   nightly backups leveraging

--- a/rackspace.yaml
+++ b/rackspace.yaml
@@ -18,7 +18,7 @@ instructions: |
   #### Getting Started
   If you're new to MySQL, the [Manual](http://dev.mysql.com/doc/refman/5.5/en/index.html)
   documentation will step you through the basics of configuration, connecting,
- user, and  permission management.
+  user, and  permission management.
 
   As a part of your server configuration, your server will be configured to run
   nightly backups leveraging


### PR DESCRIPTION
The current getting started link, now goes to an article not found on the Oracle site. I've looked around and the best I've found is the manual. It has all the same pieces as the original (looked it up in archive.org), but it's quite as simple. Unfortunate, but if someone has a better link I'm game.